### PR TITLE
Variable type correction

### DIFF
--- a/arduino_firmware/robotArm_v0.81/RampsStepper.h
+++ b/arduino_firmware/robotArm_v0.81/RampsStepper.h
@@ -21,8 +21,8 @@ public:
   
   void setReductionRatio(float gearRatio, int stepsPerRev);
 private:
-  int stepperStepTargetPosition;
-  int stepperStepPosition;
+  long stepperStepTargetPosition;
+  long stepperStepPosition;
   int stepPin;
   int dirPin;
   int enablePin;  


### PR DESCRIPTION
Fixes a critical overflow issue in motion control variables, specifically affecting the E axis. The problem caused loss of motor control, vibrations, and operational failures when the programmed travel exceeded 204 mm, due to the 16-bit limit of the step counter variables. The variables have been updated to 32-bit to extend their range and ensure proper functionality for travels greater than 204 mm.